### PR TITLE
Doc and example improvements

### DIFF
--- a/client/src/main/java/org/camunda/bpm/client/ExternalTaskClientBuilder.java
+++ b/client/src/main/java/org/camunda/bpm/client/ExternalTaskClientBuilder.java
@@ -13,6 +13,7 @@
 package org.camunda.bpm.client;
 
 import org.camunda.bpm.client.backoff.BackoffStrategy;
+import org.camunda.bpm.client.backoff.ExponentialBackoffStrategy;
 import org.camunda.bpm.client.exception.ExternalTaskClientException;
 import org.camunda.bpm.client.interceptor.ClientRequestInterceptor;
 
@@ -54,7 +55,7 @@ public interface ExternalTaskClientBuilder {
 
   /**
    * Specifies the maximum amount of tasks that can be fetched within one request.
-   * This information is optional.
+   * This information is optional. Default is 10.
    *
    * @param maxTasks which are supposed to be fetched within one request
    * @return the builder
@@ -109,7 +110,7 @@ public interface ExternalTaskClientBuilder {
 
   /**
    * Adds a custom strategy to the client for defining the org.camunda.bpm.client.backoff between two requests.
-   * This information is optional.
+   * This information is optional. Default is {@link ExponentialBackoffStrategy}
    *
    * @param backoffStrategy which realizes a custom org.camunda.bpm.client.backoff strategy
    * @return the builder

--- a/client/src/main/java/org/camunda/bpm/client/topic/impl/TopicSubscriptionManager.java
+++ b/client/src/main/java/org/camunda/bpm/client/topic/impl/TopicSubscriptionManager.java
@@ -123,6 +123,7 @@ public class TopicSubscriptionManager implements Runnable {
     List<ExternalTask> externalTasks = Collections.emptyList();
 
     try {
+      LOG.fetchAndLock(subscriptions);
       externalTasks = engineClient.fetchAndLock(subscriptions);
     } catch (EngineClientException e) {
       LOG.exceptionWhilePerformingFetchAndLock(e);

--- a/client/src/main/java/org/camunda/bpm/client/topic/impl/TopicSubscriptionManagerLogger.java
+++ b/client/src/main/java/org/camunda/bpm/client/topic/impl/TopicSubscriptionManagerLogger.java
@@ -12,9 +12,12 @@
  */
 package org.camunda.bpm.client.topic.impl;
 
+import java.util.List;
+
 import org.camunda.bpm.client.exception.ExternalTaskClientException;
 import org.camunda.bpm.client.impl.EngineClientException;
 import org.camunda.bpm.client.impl.ExternalTaskClientLogger;
+import org.camunda.bpm.client.topic.impl.dto.TopicRequestDto;
 
 /**
  * @author Tassilo Weidner
@@ -57,6 +60,12 @@ public class TopicSubscriptionManagerLogger extends ExternalTaskClientLogger {
     logError(
       "007",
       String.format("Task handler is null for topic '%s'.", topicName));
+  }
+  
+  protected void fetchAndLock(List<TopicRequestDto> subscriptions) {
+    logDebug(
+      "008", 
+      String.format("Fetch and lock new external tasks for %d topics", subscriptions.size()));
   }
 
 }

--- a/examples/loan-granting/src/main/java/org/camunda/bpm/App.java
+++ b/examples/loan-granting/src/main/java/org/camunda/bpm/App.java
@@ -39,8 +39,6 @@ public class App {
         System.out.println("The External Task " + externalTask.getId() + " has been completed!");
 
       }).open();
-
-    Thread.sleep(1000 * 60 * 5);
   }
 
 }

--- a/examples/order-handling/src/main/java/org/camunda/bpm/App.java
+++ b/examples/order-handling/src/main/java/org/camunda/bpm/App.java
@@ -46,8 +46,6 @@ public class App {
           " has been completed!");
 
       }).open();
-
-    Thread.sleep(1000 * 60 * 5);
   }
 
 }


### PR DESCRIPTION
After playing around with the client and adopting the examples for the training I found some small improvements.

* Name the default values
* write a log about fetchAndLock to follow the backoff strategy and see when the client fetches new tasks
* remove the Thread.sleep from the examples as they have no effect. subscriptionBuilder.open() will run forever.