### PR TITLE
use system properties when constructing HttpClient

### DIFF
--- a/client/src/main/java/org/camunda/bpm/client/impl/RequestExecutor.java
+++ b/client/src/main/java/org/camunda/bpm/client/impl/RequestExecutor.java
@@ -162,6 +162,7 @@ public class RequestExecutor {
 
   protected void initHttpClient(RequestInterceptorHandler requestInterceptorHandler) {
     HttpClientBuilder httpClientBuilder = HttpClients.custom()
+      .useSystemProperties()
       .addInterceptorLast(requestInterceptorHandler);
 
     this.httpClient = httpClientBuilder.build();


### PR DESCRIPTION
Comunda external task client should be aware of system properties and use proxy settings if configured.