### PR TITLE
Backoff strategy can be disabled and doc improvements

### DIFF
--- a/client/src/main/java/org/camunda/bpm/client/ExternalTaskClientBuilder.java
+++ b/client/src/main/java/org/camunda/bpm/client/ExternalTaskClientBuilder.java
@@ -80,9 +80,9 @@ public interface ExternalTaskClientBuilder {
   ExternalTaskClientBuilder dateFormat(String dateFormat);
 
   /**
-   * Specifies the maximum waiting time for the response of fetched and locked external tasks.
-   * The response is performed immediately, if external tasks are available in the moment of the request.
-   * This information is optional.
+   * Specifies the Long Polling timeout in milliseconds. 
+   * The response is performed immediately, if external tasks are available in the moment of the request (Long Polling).
+   * This information is optional. Usage of Long Polling is disabled by default.
    *
    * @param asyncResponseTimeout of fetched and locked external tasks
    * @return the builder

--- a/client/src/main/java/org/camunda/bpm/client/backoff/ExponentialBackoffStrategy.java
+++ b/client/src/main/java/org/camunda/bpm/client/backoff/ExponentialBackoffStrategy.java
@@ -34,9 +34,9 @@ public class ExponentialBackoffStrategy implements BackoffStrategy {
   }
 
   /**
-   * @param initTime for which the client is suspended after the first request
+   * @param initTime in milliseconds for which the client is suspended after the first request
    * @param factor is the base of the power by which the waiting time increases
-   * @param maxTime for which the client can be suspended
+   * @param maxTime in milliseconds for which the client can be suspended
    */
   public ExponentialBackoffStrategy(long initTime, float factor, long maxTime) {
     this.initTime = initTime;

--- a/client/src/main/java/org/camunda/bpm/client/backoff/NoBackoffStrategy.java
+++ b/client/src/main/java/org/camunda/bpm/client/backoff/NoBackoffStrategy.java
@@ -1,0 +1,24 @@
+package org.camunda.bpm.client.backoff;
+
+import java.util.List;
+
+import org.camunda.bpm.client.task.ExternalTask;
+
+/**
+ * No backoff. The next call is done immediately after the previous.
+ * 
+ * @author Ingo Richtsmeier
+ *
+ */
+public class NoBackoffStrategy implements BackoffStrategy {
+
+  @Override
+  public void reconfigure(List<ExternalTask> externalTasks) {
+  }
+
+  @Override
+  public long calculateBackoffTime() {
+    return 0;
+  }
+
+}

--- a/client/src/test/java/org/camunda/bpm/client/backoff/ExponentialBackoffStrategyTest.java
+++ b/client/src/test/java/org/camunda/bpm/client/backoff/ExponentialBackoffStrategyTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class ExponentialBackoffStrategyTest {
 
-  protected ExponentialBackoffStrategy backoffStrategy;
+  protected BackoffStrategy backoffStrategy;
 
   @Before
   public void setup() {

--- a/client/src/test/java/org/camunda/bpm/client/backoff/NoBackoffStrategyTest.java
+++ b/client/src/test/java/org/camunda/bpm/client/backoff/NoBackoffStrategyTest.java
@@ -1,0 +1,39 @@
+package org.camunda.bpm.client.backoff;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.assertj.core.util.Lists;
+import org.camunda.bpm.client.task.impl.ExternalTaskImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NoBackoffStrategyTest {
+  
+  protected BackoffStrategy backoffStrategy;
+  
+  @Before
+  public void setup() {
+    backoffStrategy = new NoBackoffStrategy();
+  }
+  
+  @Test
+  public void dontWait() {
+    long backoffTime = backoffStrategy.calculateBackoffTime();
+    assertThat(backoffTime).isEqualTo(0L);
+  }
+  
+  @Test
+  public void backOffForZeroTasks() {
+    backoffStrategy.reconfigure(null);
+    long backoffTime = backoffStrategy.calculateBackoffTime();
+    assertThat(backoffTime).isEqualTo(0L);
+  }
+  
+  @Test
+  public void backOffForOneTask() {
+    backoffStrategy.reconfigure(Lists.newArrayList(new ExternalTaskImpl()));
+    long backoffTime = backoffStrategy.calculateBackoffTime();
+    assertThat(backoffTime).isEqualTo(0L);
+  }
+
+}


### PR DESCRIPTION
Adjusted the docs to clarify the Long Polling control and the backoff strategy.

Sorry for adding old pull request again, but im not the master on GIT.

related to CAM-9280