### PR TITLE
CAM-9563 Add adjustable ttl for httpclient

### DIFF
--- a/client/src/main/java/org/camunda/bpm/client/impl/RequestExecutor.java
+++ b/client/src/main/java/org/camunda/bpm/client/impl/RequestExecutor.java
@@ -17,6 +17,7 @@ package org.camunda.bpm.client.impl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -164,7 +165,10 @@ public class RequestExecutor {
   }
 
   protected void initHttpClient(RequestInterceptorHandler requestInterceptorHandler) {
+    final long ttl = Long.parseLong(System.getProperty("camunda.httpclient.ttl", "-1"));
+
     HttpClientBuilder httpClientBuilder = HttpClients.custom()
+      .setConnectionTimeToLive(ttl, TimeUnit.SECONDS)
       .useSystemProperties()
       .addInterceptorLast(requestInterceptorHandler);
 


### PR DESCRIPTION
Added system configuration value to set httpclient ttl (time to live) at runtime
The default ttl of -1 'infinite' is not flexible enough for all use cases