### PR TITLE
CAM-10630: feat(client): client can fetch by priority

### DIFF
--- a/client/src/it/java/org/camunda/bpm/client/util/ProcessModels.java
+++ b/client/src/it/java/org/camunda/bpm/client/util/ProcessModels.java
@@ -78,6 +78,21 @@ public class ProcessModels {
       .endEvent("endEvent")
       .done();
 
+  public static final BpmnModelInstance TWO_PRIORITISED_EXTERNAL_TASKS_PROCESS =
+      newModel()
+          .startEvent("startEvent")
+            .parallelGateway("parallelGateway")
+            .serviceTask(EXTERNAL_TASK_ONE_ID)
+              .camundaExternalTask(EXTERNAL_TASK_TOPIC_FOO)
+                .camundaTaskPriority(String.valueOf(EXTERNAL_TASK_PRIORITY))
+            .endEvent("endEvent1")
+            .moveToLastGateway()
+            .serviceTask(EXTERNAL_TASK_TWO_ID)
+              .camundaExternalTask(EXTERNAL_TASK_TOPIC_FOO)
+                .camundaTaskPriority(String.valueOf(EXTERNAL_TASK_PRIORITY + 1000L))
+            .endEvent("endEvent2")
+            .done();
+
   public static final BpmnModelInstance ONE_EXTERNAL_TASK_WITH_OUTPUT_PARAM_PROCESS =
       newModel(PROCESS_KEY_2)
       .startEvent("startEvent")

--- a/client/src/main/java/org/camunda/bpm/client/ExternalTaskClientBuilder.java
+++ b/client/src/main/java/org/camunda/bpm/client/ExternalTaskClientBuilder.java
@@ -67,6 +67,15 @@ public interface ExternalTaskClientBuilder {
   ExternalTaskClientBuilder maxTasks(int maxTasks);
 
   /**
+   * Specifies whether tasks should be fetched based on their priority or arbitrarily.
+   * This information is optional. Default is <code>true</code>.
+   *
+   * @param usePriority when fetching and locking tasks
+   * @return the builder
+   */
+  ExternalTaskClientBuilder usePriority(boolean usePriority);
+
+  /**
    * Specifies the serialization format that is used to serialize objects when no specific
    * format is requested. This option defaults to application/json.
    *

--- a/client/src/main/java/org/camunda/bpm/client/impl/EngineClient.java
+++ b/client/src/main/java/org/camunda/bpm/client/impl/EngineClient.java
@@ -54,20 +54,26 @@ public class EngineClient {
   protected String baseUrl;
   protected String workerId;
   protected int maxTasks;
+  protected boolean usePriority;
   protected Long asyncResponseTimeout;
   protected RequestExecutor engineInteraction;
   protected TypedValues typedValues;
 
   public EngineClient(String workerId, int maxTasks, Long asyncResponseTimeout, String baseUrl, RequestExecutor engineInteraction) {
+    this(workerId, maxTasks, asyncResponseTimeout, baseUrl, engineInteraction, true);
+  }
+
+  public EngineClient(String workerId, int maxTasks, Long asyncResponseTimeout, String baseUrl, RequestExecutor engineInteraction, boolean usePriority) {
     this.workerId = workerId;
     this.asyncResponseTimeout = asyncResponseTimeout;
     this.maxTasks = maxTasks;
+    this.usePriority = usePriority;
     this.engineInteraction = engineInteraction;
     this.baseUrl = baseUrl;
   }
 
   public List<ExternalTask> fetchAndLock(List<TopicRequestDto> topics) throws EngineClientException {
-    FetchAndLockRequestDto payload = new FetchAndLockRequestDto(workerId, maxTasks, asyncResponseTimeout, topics);
+    FetchAndLockRequestDto payload = new FetchAndLockRequestDto(workerId, maxTasks, asyncResponseTimeout, topics, usePriority);
     String resourceUrl = baseUrl + FETCH_AND_LOCK_RESOURCE_PATH;
     ExternalTask[] externalTasks = engineInteraction.postRequest(resourceUrl, payload, ExternalTaskImpl[].class);
     return Arrays.asList(externalTasks);

--- a/client/src/main/java/org/camunda/bpm/client/impl/ExternalTaskClientBuilderImpl.java
+++ b/client/src/main/java/org/camunda/bpm/client/impl/ExternalTaskClientBuilderImpl.java
@@ -68,6 +68,7 @@ public class ExternalTaskClientBuilderImpl implements ExternalTaskClientBuilder 
   protected String baseUrl;
   protected String workerId;
   protected int maxTasks;
+  protected boolean usePriority;
   protected Long asyncResponseTimeout;
   protected long lockDuration;
 
@@ -89,6 +90,7 @@ public class ExternalTaskClientBuilderImpl implements ExternalTaskClientBuilder 
   public ExternalTaskClientBuilderImpl() {
     // default values
     this.maxTasks = 10;
+    this.usePriority = true;
     this.asyncResponseTimeout = null;
     this.lockDuration = 20_000;
     this.interceptors = new ArrayList<>();
@@ -114,6 +116,11 @@ public class ExternalTaskClientBuilderImpl implements ExternalTaskClientBuilder 
 
   public ExternalTaskClientBuilder maxTasks(int maxTasks) {
     this.maxTasks = maxTasks;
+    return this;
+  }
+
+  public ExternalTaskClientBuilder usePriority(boolean usePriority) {
+    this.usePriority = usePriority;
     return this;
   }
 
@@ -256,7 +263,7 @@ public class ExternalTaskClientBuilderImpl implements ExternalTaskClientBuilder 
   protected void initEngineClient() {
     RequestInterceptorHandler requestInterceptorHandler = new RequestInterceptorHandler(interceptors);
     RequestExecutor requestExecutor = new RequestExecutor(requestInterceptorHandler, objectMapper);
-    engineClient = new EngineClient(workerId, maxTasks, asyncResponseTimeout, baseUrl, requestExecutor);
+    engineClient = new EngineClient(workerId, maxTasks, asyncResponseTimeout, baseUrl, requestExecutor, usePriority);
   }
 
   protected void initTopicSubscriptionManager() {

--- a/client/src/main/java/org/camunda/bpm/client/topic/impl/dto/FetchAndLockRequestDto.java
+++ b/client/src/main/java/org/camunda/bpm/client/topic/impl/dto/FetchAndLockRequestDto.java
@@ -29,18 +29,28 @@ import java.util.List;
 public class FetchAndLockRequestDto extends RequestDto {
 
   protected int maxTasks;
+  protected boolean usePriority;
   protected Long asyncResponseTimeout;
   protected List<TopicRequestDto> topics = new ArrayList<>();
 
   public FetchAndLockRequestDto(String workerId, int maxTasks, Long asyncResponseTimeout, List<TopicRequestDto> topics) {
+    this(workerId, maxTasks, asyncResponseTimeout, topics, true);
+  }
+
+  public FetchAndLockRequestDto(String workerId, int maxTasks, Long asyncResponseTimeout, List<TopicRequestDto> topics, boolean usePriority) {
     super(workerId);
     this.maxTasks = maxTasks;
+    this.usePriority = usePriority;
     this.asyncResponseTimeout = asyncResponseTimeout;
     this.topics = topics;
   }
 
   public int getMaxTasks() {
     return maxTasks;
+  }
+
+  public boolean isUsePriority() {
+    return usePriority;
   }
 
   public List<TopicRequestDto> getTopics() {


### PR DESCRIPTION
* Add an option for the client to fetch and lock tasks by priority.
* The usePriority option is enabled by default.
* Add test coverage for the new option.

Related to [CAM-10630](https://app.camunda.com/jira/browse/CAM-10630)