### PR TITLE
fix(client): fix failing tests

### DIFF
--- a/client/src/it/java/org/camunda/bpm/client/topic/TopicSubscriptionIT.java
+++ b/client/src/it/java/org/camunda/bpm/client/topic/TopicSubscriptionIT.java
@@ -279,8 +279,8 @@ public class TopicSubscriptionIT {
 
     List<ExternalTask> handledTasks = handler.getHandledTasks();
     assertThat(handledTasks.size()).isEqualTo(2);
-    assertThat(handledTasks.get(0).getProcessDefinitionVersionTag()).isEqualTo(PROCESS_DEFINITION_VERSION_TAG);
-    assertThat(handledTasks.get(1).getProcessDefinitionVersionTag()).isEqualTo(null);
+    assertThat(handledTasks.get(0).getProcessDefinitionVersionTag()).isEqualTo(null);
+    assertThat(handledTasks.get(1).getProcessDefinitionVersionTag()).isEqualTo(PROCESS_DEFINITION_VERSION_TAG);
   }
 
   @Test


### PR DESCRIPTION
* Change process definition key assertion order in Topic Subscribtion test. Test was failing due to enabling , which changes the fetching order of the tasks.

Related to CAM-10630