### PR TITLE
fix(client): File variables now get properly loaded in case of that they are provided as local variables.

### DIFF
--- a/client/src/main/java/org/camunda/bpm/client/impl/EngineClient.java
+++ b/client/src/main/java/org/camunda/bpm/client/impl/EngineClient.java
@@ -26,6 +26,8 @@ import org.camunda.bpm.client.task.impl.dto.BpmnErrorRequestDto;
 import org.camunda.bpm.client.task.impl.dto.CompleteRequestDto;
 import org.camunda.bpm.client.task.impl.dto.ExtendLockRequestDto;
 import org.camunda.bpm.client.task.impl.dto.FailureRequestDto;
+import org.camunda.bpm.client.task.impl.dto.VariableInstanceRequestDto;
+import org.camunda.bpm.client.task.impl.dto.VariableInstanceResponseDto;
 import org.camunda.bpm.client.topic.impl.dto.FetchAndLockRequestDto;
 import org.camunda.bpm.client.topic.impl.dto.TopicRequestDto;
 import org.camunda.bpm.client.variable.impl.TypedValueField;
@@ -47,9 +49,9 @@ public class EngineClient {
   public static final String EXTEND_LOCK_RESOURCE_PATH = ID_RESOURCE_PATH + "/extendLock";
   public static final String NAME_PATH_PARAM = "{name}";
   public static final String EXECUTION_RESOURCE_PATH = "/execution";
+  public static final String VARIABLE_INSTANCE_PATH = "/variable-instance";
   public static final String EXECUTION_ID_RESOURCE_PATH = EXECUTION_RESOURCE_PATH + "/" + ID_PATH_PARAM;
-  public static final String GET_LOCAL_VARIABLE =  EXECUTION_ID_RESOURCE_PATH + "/localVariables/" + NAME_PATH_PARAM;
-  public static final String GET_LOCAL_BINARY_VARIABLE =  GET_LOCAL_VARIABLE + "/data";
+  public static final String GET_VARIABLE_INSTANCE_BINARY_VARIABLE = VARIABLE_INSTANCE_PATH + "/" + ID_PATH_PARAM + "/data";
 
   protected String baseUrl;
   protected String workerId;
@@ -118,9 +120,12 @@ public class EngineClient {
   }
 
   public byte[] getLocalBinaryVariable(String variableName, String processInstanceId) throws EngineClientException {
-    String resourcePath = baseUrl + GET_LOCAL_BINARY_VARIABLE
-      .replace(ID_PATH_PARAM, processInstanceId)
-      .replace(NAME_PATH_PARAM, variableName);
+    VariableInstanceResponseDto[] variables = engineInteraction.postRequest(baseUrl + VARIABLE_INSTANCE_PATH, new VariableInstanceRequestDto(workerId, processInstanceId, variableName), VariableInstanceResponseDto[].class);
+    if(variables.length != 1){
+        throw new EngineClientException("Unexpected count of variables returned " + variables.length + " expected count 1.");
+    }
+    String resourcePath = baseUrl + GET_VARIABLE_INSTANCE_BINARY_VARIABLE
+            .replace(ID_PATH_PARAM, variables[0].getId());
 
     return engineInteraction.getRequest(resourcePath);
   }

--- a/client/src/main/java/org/camunda/bpm/client/task/impl/dto/VariableInstanceRequestDto.java
+++ b/client/src/main/java/org/camunda/bpm/client/task/impl/dto/VariableInstanceRequestDto.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Camunda Services GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.client.task.impl.dto;
+
+import java.util.Collections;
+import java.util.List;
+import org.camunda.bpm.client.impl.RequestDto;
+
+/**
+ *
+ * @author adakl
+ */
+public class VariableInstanceRequestDto extends RequestDto{
+    protected List<String> processInstanceIdIn;
+    protected String variableName;
+
+    public VariableInstanceRequestDto(String workerId, String procesInstanceId, String variableName) {
+        super(workerId);
+        this.processInstanceIdIn = Collections.singletonList(procesInstanceId);
+        this.variableName = variableName;
+    }
+
+    public List<String> getProcessInstanceIdIn() {
+        return processInstanceIdIn;
+    }
+
+    public String getVariableName() {
+        return variableName;
+    }
+    
+}

--- a/client/src/main/java/org/camunda/bpm/client/task/impl/dto/VariableInstanceResponseDto.java
+++ b/client/src/main/java/org/camunda/bpm/client/task/impl/dto/VariableInstanceResponseDto.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Camunda Services GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.client.task.impl.dto;
+
+/**
+ *
+ * @author adakl
+ */
+public class VariableInstanceResponseDto {
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+    
+    
+}


### PR DESCRIPTION
Hi,

When using the client I came across a problem when passing file variables to external task.

If a file variable is passed to a ExternalTask as `inputParameter` (local variable)  loading the variable value fails because the variable is not present in result of query `/execution/<PROCESS_INSTANCE_ID>/localVariables/<NAME>/data`. (It is however present in  `/execution/<EXECUTION_ID>/localVariables/<NAME>/data` but the global variables are missing here...)

I fixed this by using `/variable-instance` endpoint where all variables both local and global are present. From this endpoint I first load the variable's ID and than load the data by calling `/variable-instance/<VARIABLE_ID>/data`. This solution consists of two API requests but I don't think this could be done in a single request because in `fetchAndLock` there is no data based on which we could differentiate whether the variable is local or global.

Adam