### PR TITLE
CAM-12653: feat(client): lock external task without fetch

### DIFF
--- a/client/src/it/java/org/camunda/bpm/client/task/ExternalTaskHandlerIT.java
+++ b/client/src/it/java/org/camunda/bpm/client/task/ExternalTaskHandlerIT.java
@@ -294,6 +294,46 @@ public class ExternalTaskHandlerIT {
   }
 
   @Test
+  public void shouldLock() {
+    // given
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
+      client.unlock(task);
+      client.lock(task, LOCK_DURATION * 10);
+    });
+
+    // when
+    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+      .handler(handler)
+      .open();
+
+    // then
+    clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
+    ExternalTask externalTaskBeforeLock = handler.getHandledTasks().get(0);
+    ExternalTask externalTaskAfterLock = engineRule.getExternalTaskByProcessInstanceId(processInstance.getId());
+    assertThat(externalTaskAfterLock.getLockExpirationTime()).isAfter(externalTaskBeforeLock.getLockExpirationTime());
+  }
+
+  @Test
+  public void shouldLockById() {
+    // given
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
+      client.unlock(task);
+      client.lock(task.getId(), LOCK_DURATION * 10);
+    });
+
+    // when
+    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+      .handler(handler)
+      .open();
+
+    // then
+    clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
+    ExternalTask externalTaskBeforeLock = handler.getHandledTasks().get(0);
+    ExternalTask externalTaskAfterLock = engineRule.getExternalTaskByProcessInstanceId(processInstance.getId());
+    assertThat(externalTaskAfterLock.getLockExpirationTime()).isAfter(externalTaskBeforeLock.getLockExpirationTime());
+  }
+
+  @Test
   public void shouldExtendLock() {
     // given
     RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {

--- a/client/src/it/java/org/camunda/bpm/client/task/ExternalTaskHandlerIT.java
+++ b/client/src/it/java/org/camunda/bpm/client/task/ExternalTaskHandlerIT.java
@@ -297,7 +297,7 @@ public class ExternalTaskHandlerIT {
   public void shouldLock() {
     // given
     RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.unlock(task);
+      // an external task may be locked again by the same worker
       client.lock(task, LOCK_DURATION * 10);
     });
 
@@ -317,7 +317,7 @@ public class ExternalTaskHandlerIT {
   public void shouldLockById() {
     // given
     RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.unlock(task);
+      // an external task may be locked again by the same worker
       client.lock(task.getId(), LOCK_DURATION * 10);
     });
 

--- a/client/src/main/java/org/camunda/bpm/client/impl/EngineClient.java
+++ b/client/src/main/java/org/camunda/bpm/client/impl/EngineClient.java
@@ -26,6 +26,7 @@ import org.camunda.bpm.client.task.impl.dto.BpmnErrorRequestDto;
 import org.camunda.bpm.client.task.impl.dto.CompleteRequestDto;
 import org.camunda.bpm.client.task.impl.dto.ExtendLockRequestDto;
 import org.camunda.bpm.client.task.impl.dto.FailureRequestDto;
+import org.camunda.bpm.client.task.impl.dto.LockRequestDto;
 import org.camunda.bpm.client.topic.impl.dto.FetchAndLockRequestDto;
 import org.camunda.bpm.client.topic.impl.dto.TopicRequestDto;
 import org.camunda.bpm.client.variable.impl.TypedValueField;
@@ -40,11 +41,12 @@ public class EngineClient {
   protected static final String FETCH_AND_LOCK_RESOURCE_PATH = EXTERNAL_TASK_RESOURCE_PATH + "/fetchAndLock";
   public static final String ID_PATH_PARAM = "{id}";
   protected static final String ID_RESOURCE_PATH = EXTERNAL_TASK_RESOURCE_PATH + "/" + ID_PATH_PARAM;
+  public static final String LOCK_RESOURCE_PATH = ID_RESOURCE_PATH + "/lock";
+  public static final String EXTEND_LOCK_RESOURCE_PATH = ID_RESOURCE_PATH + "/extendLock";
   public static final String UNLOCK_RESOURCE_PATH = ID_RESOURCE_PATH + "/unlock";
   public static final String COMPLETE_RESOURCE_PATH = ID_RESOURCE_PATH + "/complete";
   public static final String FAILURE_RESOURCE_PATH = ID_RESOURCE_PATH + "/failure";
   public static final String BPMN_ERROR_RESOURCE_PATH = ID_RESOURCE_PATH + "/bpmnError";
-  public static final String EXTEND_LOCK_RESOURCE_PATH = ID_RESOURCE_PATH + "/extendLock";
   public static final String NAME_PATH_PARAM = "{name}";
   public static final String EXECUTION_RESOURCE_PATH = "/execution";
   public static final String EXECUTION_ID_RESOURCE_PATH = EXECUTION_RESOURCE_PATH + "/" + ID_PATH_PARAM;
@@ -77,6 +79,13 @@ public class EngineClient {
     String resourceUrl = baseUrl + FETCH_AND_LOCK_RESOURCE_PATH;
     ExternalTask[] externalTasks = engineInteraction.postRequest(resourceUrl, payload, ExternalTaskImpl[].class);
     return Arrays.asList(externalTasks);
+  }
+
+  public void lock(String taskId, long lockDuration) throws EngineClientException {
+    LockRequestDto payload = new LockRequestDto(workerId, lockDuration);
+    String resourcePath = LOCK_RESOURCE_PATH.replace("{id}", taskId);
+    String resourceUrl = baseUrl + resourcePath;
+    engineInteraction.postRequest(resourceUrl, payload, Void.class);
   }
 
   public void unlock(String taskId) throws EngineClientException {

--- a/client/src/main/java/org/camunda/bpm/client/task/ExternalTaskService.java
+++ b/client/src/main/java/org/camunda/bpm/client/task/ExternalTaskService.java
@@ -32,6 +32,36 @@ import java.util.Map;
 public interface ExternalTaskService {
 
   /**
+   * Locks a task by a given amount of time.
+   *
+   * Note: This method should be used to lock external tasks
+   * that have been obtained without using the fetch & lock API.
+   *
+   * @param externalTaskId the id of the external task whose lock will be extended
+   * @param lockDuration specifies the lock duration in milliseconds
+   *
+   * @throws NotFoundException if the task has been canceled and therefore does not exist anymore
+   * @throws NotAcquiredException if the task's most recent lock could not be acquired
+   * @throws ConnectionLostException if the connection could not be established
+   */
+  void lock(String externalTaskId, long lockDuration);
+
+  /**
+   * Locks a task by a given amount of time.
+   *
+   * Note: This method should be used to lock external tasks
+   * that have been obtained without using the fetch & lock API.
+   *
+   * @param externalTask which lock will be extended
+   * @param lockDuration specifies the lock duration in milliseconds
+   *
+   * @throws NotFoundException if the task has been canceled and therefore does not exist anymore
+   * @throws NotAcquiredException if the task's most recent lock could not be acquired
+   * @throws ConnectionLostException if the connection could not be established
+   */
+  void lock(ExternalTask externalTask, long lockDuration);
+
+  /**
    * Unlocks a task and clears the tasks lock expiration time and worker id.
    *
    * @param externalTask which will be unlocked

--- a/client/src/main/java/org/camunda/bpm/client/task/impl/ExternalTaskServiceImpl.java
+++ b/client/src/main/java/org/camunda/bpm/client/task/impl/ExternalTaskServiceImpl.java
@@ -38,6 +38,20 @@ public class ExternalTaskServiceImpl implements ExternalTaskService {
   }
 
   @Override
+  public void lock(ExternalTask externalTask, long lockDuration) {
+    lock(externalTask.getId(), lockDuration);
+  }
+
+  @Override
+  public void lock(String externalTaskId, long lockDuration) {
+    try {
+      engineClient.lock(externalTaskId, lockDuration);
+    } catch (EngineClientException e) {
+      throw LOG.externalTaskServiceException("locking task", e);
+    }
+  }
+
+  @Override
   public void unlock(ExternalTask externalTask) {
     try {
       engineClient.unlock(externalTask.getId());

--- a/client/src/main/java/org/camunda/bpm/client/task/impl/dto/LockRequestDto.java
+++ b/client/src/main/java/org/camunda/bpm/client/task/impl/dto/LockRequestDto.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.client.task.impl.dto;
+
+import org.camunda.bpm.client.impl.RequestDto;
+
+public class LockRequestDto extends RequestDto {
+
+  protected long lockDuration;
+
+  public LockRequestDto(String workerId, long lockDuration) {
+    super(workerId);
+    this.lockDuration = lockDuration;
+  }
+
+  public long getLockDuration() {
+    return lockDuration;
+  }
+
+}


### PR DESCRIPTION
Related to CAM-12653, CAM-7170

Note: the new test cases will pass once the Process Engine changes are included in the "master" snapshot.